### PR TITLE
Fix: Update Android build dependencies and address deprecations

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -7,8 +7,8 @@ buildscript {
         mavenCentral()
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:8.2.1'
-        classpath 'com.google.gms:google-services:4.4.0'
+        classpath 'com.android.tools.build:gradle:8.6.0'
+        classpath 'com.google.gms:google-services:4.4.2'
 
         // NOTE: Do not place your application dependencies here; they belong
         // in the individual module build.gradle files

--- a/android/gradle/wrapper/gradle-wrapper.properties
+++ b/android/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-8.2.1-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-8.8-all.zip
 networkTimeout=10000
 validateDistributionUrl=true
 zipStoreBase=GRADLE_USER_HOME

--- a/android/variables.gradle
+++ b/android/variables.gradle
@@ -1,14 +1,14 @@
 ext {
     minSdkVersion = 22
-    compileSdkVersion = 34
-    targetSdkVersion = 34
-    androidxActivityVersion = '1.8.0'
-    androidxAppCompatVersion = '1.6.1'
-    androidxCoordinatorLayoutVersion = '1.2.0'
-    androidxCoreVersion = '1.12.0'
-    androidxFragmentVersion = '1.6.2'
+    compileSdkVersion = 35
+    targetSdkVersion = 35
+    androidxActivityVersion = '1.10.1'
+    androidxAppCompatVersion = '1.7.0'
+    androidxCoordinatorLayoutVersion = '1.3.0'
+    androidxCoreVersion = '1.16.0'
+    androidxFragmentVersion = '1.8.7'
     coreSplashScreenVersion = '1.0.1'
-    androidxWebkitVersion = '1.9.0'
+    androidxWebkitVersion = '1.13.0'
     junitVersion = '4.13.2'
     androidxJunitVersion = '1.1.5'
     androidxEspressoCoreVersion = '3.5.1'

--- a/package-lock.json
+++ b/package-lock.json
@@ -54,7 +54,7 @@
         "zod": "^3.24.2"
       },
       "devDependencies": {
-        "@capacitor/cli": "^6.0.0",
+        "@capacitor/cli": "^6.2.1",
         "@types/node": "^20",
         "@types/react": "^18",
         "@types/react-dom": "^18",
@@ -113,7 +113,6 @@
       "resolved": "https://registry.npmjs.org/@capacitor/cli/-/cli-6.2.1.tgz",
       "integrity": "sha512-JKl0FpFge8PgQNInw12kcKieQ4BmOyazQ4JGJOfEpVXlgrX1yPhSZTPjngupzTCiK3I7q7iGG5kjun0fDqgSCA==",
       "dev": true,
-      "license": "MIT",
       "dependencies": {
         "@ionic/cli-framework-output": "^2.2.5",
         "@ionic/utils-fs": "^3.1.6",

--- a/package.json
+++ b/package.json
@@ -1,4 +1,3 @@
-
 {
   "name": "nextn",
   "version": "0.1.0",
@@ -62,7 +61,7 @@
     "zod": "^3.24.2"
   },
   "devDependencies": {
-    "@capacitor/cli": "^6.0.0",
+    "@capacitor/cli": "^6.2.1",
     "@types/node": "^20",
     "@types/react": "^18",
     "@types/react-dom": "^18",


### PR DESCRIPTION
This commit brings several updates to the Android build configuration:

- Updated Gradle to version 8.8.
- Updated Android Gradle Plugin to 8.6.0.
- Updated Google Services Plugin to 4.4.2.
- Updated various AndroidX libraries to their latest stable versions, including Activity, AppCompat, CoordinatorLayout, Core, Fragment, and Webkit.
- Updated `compileSdkVersion` and `targetSdkVersion` to 35.

These changes address potential deprecation issues and ensure the project uses more recent and supported versions of its core dependencies, leading to a successful debug build.