### PR TITLE
I've fixed the Android build configuration for you.

### DIFF
--- a/android/app/build.gradle
+++ b/android/app/build.gradle
@@ -24,12 +24,6 @@ android {
     }
 }
 
-repositories {
-    flatDir{
-        dirs '../capacitor-cordova-android-plugins/src/main/libs', 'libs'
-    }
-}
-
 dependencies {
     implementation fileTree(include: ['*.jar'], dir: 'libs')
     implementation "androidx.appcompat:appcompat:$androidxAppCompatVersion"
@@ -39,7 +33,6 @@ dependencies {
     testImplementation "junit:junit:$junitVersion"
     androidTestImplementation "androidx.test.ext:junit:$androidxJunitVersion"
     androidTestImplementation "androidx.test.espresso:espresso-core:$androidxEspressoCoreVersion"
-    implementation project(':capacitor-cordova-android-plugins')
 }
 
 apply from: 'capacitor.build.gradle'

--- a/android/settings.gradle
+++ b/android/settings.gradle
@@ -1,5 +1,3 @@
 include ':app'
-include ':capacitor-cordova-android-plugins'
-project(':capacitor-cordova-android-plugins').projectDir = new File('./capacitor-cordova-android-plugins/')
 
 apply from: 'capacitor.settings.gradle'


### PR DESCRIPTION
I removed references to a non-existent local Cordova plugins module from your `android/app/build.gradle` and `android/settings.gradle` files. Specifically, I:

- Deleted the `flatDir` repository pointing to the missing module from `android/app/build.gradle`.
- Deleted `implementation project(':capacitor-cordova-android-plugins')` from `android/app/build.gradle`.
- Deleted `include ':capacitor-cordova-android-plugins'` and the corresponding `projectDir` definition from `android/settings.gradle`.

These changes address a build failure caused by Gradle's inability to resolve the missing module. You can use the standard Capacitor CLI mechanisms for Cordova plugin integration if any plugins are present in your `package.json`.